### PR TITLE
Remove unnecessary CFLAGS in build_nng.sh

### DIFF
--- a/build_nng.sh
+++ b/build_nng.sh
@@ -21,7 +21,7 @@ cmake_args="$cmake_args"
     rm -rf build &&
     mkdir build &&
     cd build &&
-    CFLAGS=-fPIC cmake $cmake_args .. &&
-    CFLAGS=-fPIC cmake --build .
+    cmake $cmake_args .. &&
+    cmake --build .
 
 )


### PR DESCRIPTION
This works on my macOS (High Sierra v10.13.5) which has a bunch of Homebrew packages installed as well as a fresh* Ubuntu 14.04, fresh* Ubuntu 16.04, and fresh* Ubuntu 18.04.

\* "Fresh", meaning a brand-new installation with only the packages required to download and build this.