### PR TITLE
Documentation update for recv_buffer_size option

### DIFF
--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -167,7 +167,7 @@ class Socket:
             or select().
         recv_max_size (int): The largest size of a message to receive.
             Messages larger than this size will be silently dropped.  A size of
-            -1 indicates unlimited size.
+            0 indicates unlimited size.
 
     See also the nng man pages document for options:
 


### PR DESCRIPTION
According to the `v1.1.0` documentation for `nng` (https://nanomsg.github.io/nng/man/v1.1.0/nng_options.5), setting `recv_buffer_size = 0` is the right way to set an unlimited receive buffer size, so I'm updating the internal documentation for this. Confirmed that this works on my system with nng version v1.1.0.

Thanks for maintaining a great API!