### PR TITLE
Support for nng_msg as Message

### DIFF
--- a/pynng/__init__.py
+++ b/pynng/__init__.py
@@ -30,7 +30,7 @@ from .exceptions import (
     NotSupported,
     AddressInUse,
     BadState,
-    NoSuchFile,
+    NoEntry,
     ProtocolError,
     DestinationUnreachable,
     AddressInvalid,

--- a/pynng/__init__.py
+++ b/pynng/__init__.py
@@ -14,6 +14,7 @@ from .nng import (
     Listener,
     Dialer,
     Pipe,
+    Message,
 )
 
 from .exceptions import (

--- a/pynng/__init__.py
+++ b/pynng/__init__.py
@@ -51,5 +51,6 @@ from .exceptions import (
     BadType,
     Internal,
     check_err,
+    MessageStateError
 )
 

--- a/pynng/_aio.py
+++ b/pynng/_aio.py
@@ -177,6 +177,13 @@ class AIOHelper:
         check_err(self._lib_asend(self._lib_obj, self.aio))
         return await self.awaitable
 
+    async def asend_msg(self, msg):
+        """
+        Asynchronously send a Message
+
+        """
+        raise NotImplementedError()
+
     def _free(self):
         """
         Free resources allocated with nng

--- a/pynng/exceptions.py
+++ b/pynng/exceptions.py
@@ -177,6 +177,12 @@ EXCEPTION_MAP = {
 }
 
 
+class MessageStateError(Exception):
+    """
+    Indicates that a Message was trying to be used in an invalid way.
+    """
+
+
 def check_err(err):
     """
     Raises an exception if the return value of an nng_function is nonzero.

--- a/pynng/exceptions.py
+++ b/pynng/exceptions.py
@@ -61,7 +61,7 @@ class BadState(NNGException):  # NNG_ESTATE
     pass
 
 
-class NoSuchFile(NNGException):  # NNG_ENOENT
+class NoEntry(NNGException):  # NNG_ENOENT
     pass
 
 
@@ -154,7 +154,7 @@ EXCEPTION_MAP = {
     nng.NNG_ENOTSUP: NotSupported,
     nng.NNG_EADDRINUSE: AddressInUse,
     nng.NNG_ESTATE: BadState,
-    nng.NNG_ENOENT: NoSuchFile,
+    nng.NNG_ENOENT: NoEntry,
     nng.NNG_EPROTO: ProtocolError,
     nng.NNG_EUNREACHABLE: DestinationUnreachable,
     nng.NNG_EADDRINVAL: AddressInvalid,

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -492,7 +492,7 @@ class Socket:
         """
         self._on_post_pipe_remove.remove(callback)
 
-    def recvmsg(self, block=True):
+    def recv_msg(self, block=True):
         """
         Return a Message object.
 
@@ -510,9 +510,6 @@ class Socket:
             raise Exception('No such pipe')
         pipe = self._pipes[pipe_id]
         return Message(msg, pipe)
-
-    def sendmsg(self, msg, block=True):
-        msg._send(block=block)
 
 
 class Bus0(Socket):
@@ -949,7 +946,7 @@ class Message:
     https://nanomsg.github.io/nng/man/tip/nng_msg.5.html
 
     There is no public constructor for this object; to get a message, you can
-    either use ``Socket.recvmsg()`` for receiving or ``Pipe.new_msg()`` to get
+    either use ``Socket.recv_msg()`` for receiving or ``Pipe.new_msg()`` to get
     a message for sending.
 
     Messages are immutable.
@@ -963,9 +960,8 @@ class Message:
         # is using: either sending with nng_sendmsg (or the async equivalent)
         # or with nng_msg_free.  We don't know how this msg will be used, but
         # we need to **ensure** that we don't try to double free.  So the only
-        # way to send a message is with the _send() and _asend() methods on the
-        # object.  Those shouldn't be called directly, though; users should
-        # only use socket.sendmsg();
+        # way to send a message is with the send() and asend() methods on the
+        # object.
         self.__sent = False
 
     @property
@@ -998,10 +994,10 @@ class Message:
             return
         lib.nng_msg_free(self._msg)
 
-    def _send(self, block=True):
+    def send(self, block=True):
         """
         Send the ``msg`` to the remote peer.
-        msg must either have been returned from Socket.recvmsg() or
+        msg must either have been returned from Socket.recv_msg() or
         Pipe.new_msg().
 
         """

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -8,13 +8,12 @@ import weakref
 import threading
 
 from ._nng import ffi, lib
-from .exceptions import check_err, ConnectionRefused
+from .exceptions import check_err, ConnectionRefused, MessageStateError
 from . import options
 from . import _aio
 
 
 logger = logging.getLogger(__name__)
-
 
 # a mapping of id(sock): sock for use in callbacks.  When a socket is
 # initialized, it adds itself to this dict.  When a socket is closed, it
@@ -494,7 +493,7 @@ class Socket:
         self._on_post_pipe_remove.remove(callback)
 
     def _get_pipe_from_msg(self, msg):
-        lib_pipe = lib.nng_msg_get_pipe(msg._lib_obj)
+        lib_pipe = lib.nng_msg_get_pipe(msg._nng_msg)
         pipe_id = lib.nng_pipe_id(lib_pipe)
         if pipe_id < 0:
             # TODO: Better exception
@@ -525,22 +524,19 @@ class Socket:
         if not block:
             flags |= lib.NNG_FLAG_NONBLOCK
         with msg._mem_freed_lock:
-            if msg._mem_freed:
-                raise Exception("TODO THIS IS NOT A GOOD EXCEPTION")
-            check_err(lib.nng_sendmsg(self.socket, msg._lib_obj, flags))
+            msg._ensure_can_send()
+            check_err(lib.nng_sendmsg(self.socket, msg._nng_msg, flags))
             msg._mem_freed = True
 
     async def asend_msg(self, msg):
         """
         Asynchronously send the Message ``msg`` on the socket.
         """
-        if msg._mem_freed:
-            # TODO
-            raise Exception("TODO THIS IS NOT A GOOD EXCEPTION")
-        with _aio.AIOHelper(self, self._async_backend) as aio:
-            val = await aio.asend_msg(msg)
-            msg._mem_freed = True
-            return val
+        with msg._mem_freed_lock:
+            msg._ensure_can_send()
+            with _aio.AIOHelper(self, self._async_backend) as aio:
+                val = await aio.asend_msg(msg)
+                return val
 
     async def arecv_msg(self):
         """
@@ -787,24 +783,31 @@ class Context:
             lib.nng_aio_free(aio)
         return py_obj
 
+    def send_msg(self, msg):
+        """
+        Synchronously send the Message ``msg`` on the context.
+
+        """
+        with msg._mem_freed_lock:
+            msg._ensure_can_send()
+            aio_p = ffi.new('nng_aio **')
+            check_err(lib.nng_aio_alloc(aio_p, ffi.NULL, ffi.NULL))
+            aio = aio_p[0]
+            try:
+                check_err(lib.nng_aio_set_msg(aio, msg._nng_msg))
+                check_err(lib.nng_ctx_send(self.context, aio))
+                msg._mem_freed = True
+                check_err(lib.nng_aio_wait(aio))
+                check_err(lib.nng_aio_result(aio))
+            finally:
+                lib.nng_aio_free(aio)
+
     def send(self, data):
         """
-        Synchronously send data on the socket.
+        Synchronously send data on the context.
         """
-        aio_p = ffi.new('nng_aio **')
-        check_err(lib.nng_aio_alloc(aio_p, ffi.NULL, ffi.NULL))
-        aio = aio_p[0]
-        try:
-            msg_p = ffi.new('nng_msg **')
-            check_err(lib.nng_msg_alloc(msg_p, 0))
-            msg = msg_p[0]
-            check_err(lib.nng_msg_append(msg, data, len(data)))
-            check_err(lib.nng_aio_set_msg(aio, msg))
-            check_err(lib.nng_ctx_send(self.context, aio))
-            check_err(lib.nng_aio_wait(aio))
-            check_err(lib.nng_aio_result(aio))
-        finally:
-            lib.nng_aio_free(aio)
+        msg = Message(data)
+        return self.send_msg(msg)
 
     def _free(self):
         ctx_err = 0
@@ -833,11 +836,9 @@ class Context:
         Asynchronously send the Message ``msg`` on the socket.
         """
         with msg._mem_freed_lock:
-            if msg._mem_freed:
-                raise Exception("TODO THIS IS NOT A GOOD EXCEPTION")
+            msg._ensure_can_send()
             with _aio.AIOHelper(self, self._socket._async_backend) as aio:
                 val = await aio.asend_msg(msg)
-                msg._mem_freed = True
                 return val
 
     async def arecv_msg(self):
@@ -1018,13 +1019,13 @@ class Message:
 
         if isinstance(data, ffi.CData) and \
                 ffi.typeof(data).cname == 'struct nng_msg *':
-            self._lib_obj = data
+            self._nng_msg = data
         else:
             msg_p = ffi.new('nng_msg **')
             check_err(lib.nng_msg_alloc(msg_p, 0))
             msg = msg_p[0]
             check_err(lib.nng_msg_append(msg, data, len(data)))
-            self._lib_obj = msg
+            self._nng_msg = msg
 
     @property
     def pipe(self):
@@ -1033,14 +1034,14 @@ class Message:
     @pipe.setter
     def pipe(self, pipe):
         if pipe is None:
-            check_err(lib.nng_msg_set_pipe(self._lib_obj, ffi.NULL))
+            check_err(lib.nng_msg_set_pipe(self._nng_msg, ffi.NULL))
             self._pipe = None
             return
         if not isinstance(pipe, Pipe):
             msg = 'pipe must be type Pipe, not {}'
             msg = msg.format(type(pipe))
             raise ValueError(msg)
-        check_err(lib.nng_msg_set_pipe(self._lib_obj, pipe.pipe))
+        check_err(lib.nng_msg_set_pipe(self._nng_msg, pipe.pipe))
         self._pipe = pipe
 
     @property
@@ -1055,8 +1056,8 @@ class Message:
         """
         with self._mem_freed_lock:
             if not self._mem_freed:
-                size = lib.nng_msg_len(self._lib_obj)
-                data = ffi.cast('char *', lib.nng_msg_body(self._lib_obj))
+                size = lib.nng_msg_len(self._nng_msg)
+                data = ffi.cast('char *', lib.nng_msg_body(self._nng_msg))
                 return ffi.buffer(data[0:size])
 
     @property
@@ -1072,8 +1073,19 @@ class Message:
             if self._mem_freed:
                 return
             else:
-                lib.nng_msg_free(self._lib_obj)
+                lib.nng_msg_free(self._nng_msg)
                 # pretty sure it's not necessary to set this, but that's okay.
                 self._mem_freed = True
 
+    def _ensure_can_send(self):
+        """
+        Raises an exception if the message's state is such that it cannot be
+        sent.  The _mem_freed_lock() must be acquired when this method is
+        called.
+
+        """
+        assert self._mem_freed_lock.locked()
+        if self._mem_freed:
+            msg = 'Attempted to send the same message more than once.'
+            raise MessageStateError(msg)
 

--- a/test/_test_util.py
+++ b/test/_test_util.py
@@ -1,0 +1,18 @@
+import time
+
+
+def wait_pipe_len(sock, expected, timeout=10):
+    """
+    Wait up to ``timeout`` seconds for the length of sock.pipes to become
+    ``expected`` value.  This prevents hardcoding sleep times, which should be
+    pretty small for local development but potentially pretty large for CI
+    runs.
+
+    """
+    now = time.time()
+    later = now + timeout
+    while time.time() < later and len(sock.pipes) != expected:
+        time.sleep(0.002)
+    return len(sock.pipes) == expected
+
+

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -70,7 +70,6 @@ def test_arecv_trio_cancel():
 def test_asend_asyncio():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
     with pynng.Pair0(listen=addr, recv_timeout=2000) as listener, \
             pynng.Pair0(dial=addr, send_timeout=2000) as dialer:
         arecv = listener.arecv()
@@ -82,7 +81,6 @@ def test_asend_asyncio():
 
 
 def test_asend_trio():
-
     async def asend_and_arecv(sender, receiver, msg):
         await sender.asend(msg)
         return await receiver.arecv()

--- a/test/test_msg.py
+++ b/test/test_msg.py
@@ -56,8 +56,10 @@ async def test_context_arecv_asend_msg():
             msg = pynng.Message(b'do i even know you')
             await ctx1.asend_msg(msg)
             msg2 = await ctx2.arecv_msg()
+            assert msg2.pipe is s2.pipes[0]
             assert msg2.bytes == b'do i even know you'
             msg3 = pynng.Message(b'yes of course i am your favorite platypus')
             await ctx2.asend_msg(msg3)
             msg4 = await ctx1.arecv_msg()
+            assert msg4.pipe is s1.pipes[0]
             assert msg4.bytes == b'yes of course i am your favorite platypus'

--- a/test/test_msg.py
+++ b/test/test_msg.py
@@ -14,7 +14,7 @@ def test_socket_send_recv_msg_from_pipe():
             pynng.Pair0(dial=addr, recv_timeout=to) as s2:
         wait_pipe_len(s1, 1)
         pipe = s1.pipes[0]
-        msg = pipe.new_msg(b'oh hello friend')
+        msg = pynng.Message(b'oh hello friend', pipe)
         assert isinstance(msg, pynng.Message)
         assert msg.bytes == b'oh hello friend'
         s1.send_msg(msg)
@@ -29,7 +29,7 @@ def test_socket_send_recv_msg():
     with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
             pynng.Pair0(dial=addr, recv_timeout=to) as s2:
         wait_pipe_len(s1, 1)
-        msg = s1.new_msg(b'we are friends, old buddy')
+        msg = pynng.Message(b'we are friends, old buddy')
         s1.send_msg(msg)
         msg2 = s2.recv_msg()
         assert msg2.bytes == b'we are friends, old buddy'
@@ -40,8 +40,7 @@ async def test_socket_arecv_asend_msg():
     with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
             pynng.Pair0(dial=addr, recv_timeout=to) as s2:
         wait_pipe_len(s1, 1)
-        pipe = s1.pipes[0]
-        msg = pipe.new_msg(b'you truly are a pal')
+        msg = pynng.Message(b'you truly are a pal')
         await s1.asend_msg(msg)
         msg2 = await s2.arecv_msg()
         assert msg2.bytes == b'you truly are a pal'
@@ -54,11 +53,11 @@ async def test_context_arecv_asend_msg():
             pynng.Rep0(dial=addr, recv_timeout=to) as s2:
         with s1.new_context() as ctx1, s2.new_context() as ctx2:
             wait_pipe_len(s1, 1)
-            msg = ctx1.new_msg(b'do i even know you')
+            msg = pynng.Message(b'do i even know you')
             await ctx1.asend_msg(msg)
             msg2 = await ctx2.arecv_msg()
             assert msg2.bytes == b'do i even know you'
-            msg3 = ctx2.new_msg(b'yes of course i am your favorite platypus')
+            msg3 = pynng.Message(b'yes of course i am your favorite platypus')
             await ctx2.asend_msg(msg3)
             msg4 = await ctx1.arecv_msg()
             assert msg4.bytes == b'yes of course i am your favorite platypus'

--- a/test/test_msg.py
+++ b/test/test_msg.py
@@ -15,8 +15,8 @@ def test_socket_send_recv_msg():
         msg = pipe.new_msg(b'oh hello friend')
         assert isinstance(msg, pynng.Message)
         assert msg.bytes == b'oh hello friend'
-        s1.sendmsg(msg)
-        msg2 = s2.recvmsg()
+        msg.send()
+        msg2 = s2.recv_msg()
         assert isinstance(msg2, pynng.Message)
         assert msg2.bytes == b'oh hello friend'
 
@@ -28,8 +28,6 @@ def test_recv_msg_has_correct_pipe():
         pipe = s1.pipes[0]
         msg = pipe.new_msg(b'oh hello friend')
         assert msg.pipe is pipe
-        s1.sendmsg(msg)
-        msg2 = s2.recvmsg()
+        msg.send()
+        msg2 = s2.recv_msg()
         assert msg2.pipe is s2.pipes[0]
-
-

--- a/test/test_msg.py
+++ b/test/test_msg.py
@@ -1,0 +1,35 @@
+import pynng
+from test._test_util import wait_pipe_len
+
+addr = 'tcp://127.0.0.1:42421'
+
+# timeout, ms
+to = 1000
+
+
+def test_socket_send_recv_msg():
+    with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
+            pynng.Pair0(dial=addr, recv_timeout=to) as s2:
+        wait_pipe_len(s1, 1)
+        pipe = s1.pipes[0]
+        msg = pipe.new_msg(b'oh hello friend')
+        assert isinstance(msg, pynng.Message)
+        assert msg.bytes == b'oh hello friend'
+        s1.sendmsg(msg)
+        msg2 = s2.recvmsg()
+        assert isinstance(msg2, pynng.Message)
+        assert msg2.bytes == b'oh hello friend'
+
+
+def test_recv_msg_has_correct_pipe():
+    with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
+            pynng.Pair0(dial=addr, recv_timeout=to) as s2:
+        wait_pipe_len(s1, 1)
+        pipe = s1.pipes[0]
+        msg = pipe.new_msg(b'oh hello friend')
+        assert msg.pipe is pipe
+        s1.sendmsg(msg)
+        msg2 = s2.recvmsg()
+        assert msg2.pipe is s2.pipes[0]
+
+

--- a/test/test_msg.py
+++ b/test/test_msg.py
@@ -1,3 +1,5 @@
+from trio.testing import trio_test
+
 import pynng
 from test._test_util import wait_pipe_len
 
@@ -7,7 +9,7 @@ addr = 'tcp://127.0.0.1:42421'
 to = 1000
 
 
-def test_socket_send_recv_msg():
+def test_socket_send_recv_msg_from_pipe():
     with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
             pynng.Pair0(dial=addr, recv_timeout=to) as s2:
         wait_pipe_len(s1, 1)
@@ -15,19 +17,32 @@ def test_socket_send_recv_msg():
         msg = pipe.new_msg(b'oh hello friend')
         assert isinstance(msg, pynng.Message)
         assert msg.bytes == b'oh hello friend'
-        msg.send()
+        s1.send_msg(msg)
+        assert msg.pipe is pipe
         msg2 = s2.recv_msg()
         assert isinstance(msg2, pynng.Message)
         assert msg2.bytes == b'oh hello friend'
+        assert msg2.pipe is s2.pipes[0]
 
 
-def test_recv_msg_has_correct_pipe():
+def test_socket_send_recv_msg():
+    with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
+            pynng.Pair0(dial=addr, recv_timeout=to) as s2:
+        wait_pipe_len(s1, 1)
+        msg = s1.new_msg(b'we are friends, old buddy')
+        s1.send_msg(msg)
+        msg2 = s2.recv_msg()
+        assert msg2.bytes == b'we are friends, old buddy'
+
+
+@trio_test
+async def test_arecv_asend_msg():
     with pynng.Pair0(listen=addr, recv_timeout=to) as s1, \
             pynng.Pair0(dial=addr, recv_timeout=to) as s2:
         wait_pipe_len(s1, 1)
         pipe = s1.pipes[0]
-        msg = pipe.new_msg(b'oh hello friend')
-        assert msg.pipe is pipe
-        msg.send()
-        msg2 = s2.recv_msg()
+        msg = pipe.new_msg(b'you truly are a pal')
+        await s1.asend_msg(msg)
+        msg2 = await s2.arecv_msg()
+        assert msg2.bytes == b'you truly are a pal'
         assert msg2.pipe is s2.pipes[0]

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -7,24 +7,9 @@ import sys
 import time
 
 import pynng
-
+from test._test_util import wait_pipe_len
 
 addr = 'tcp://127.0.0.1:31414'
-
-
-def wait_pipe_len(sock, expected, timeout=10):
-    """
-    Wait up to ``timeout`` seconds for the length of sock.pipes to become
-    ``expected`` value.  This prevents hardcoding sleep times, which should be
-    pretty small for local development but potentially pretty large for CI
-    runs.
-
-    """
-    now = time.time()
-    later = now + timeout
-    while time.time() < later and len(sock.pipes) != expected:
-        time.sleep(0.002)
-    return len(sock.pipes) == expected
 
 
 def test_pipe_gets_added_and_removed():


### PR DESCRIPTION
This is the beginning of supporting nng_msg in pynng.  Related issue is #21.

So far only sychronous methods are supported.  The API will change, I think, before this is merged; I think that my `Message` class will grow a public `send()` method.  Instead of `socket.sendmsg(msg)`, you would instead call `msg.send()`.  Feedback welcome.  To see how it's used right now, check out the tests!