### PR TITLE
Pubsub test

### DIFF
--- a/pynng/_aio.py
+++ b/pynng/_aio.py
@@ -145,7 +145,10 @@ class AIOHelper:
         if async_backend is None:
             async_backend = sniffio.current_async_library()
         if async_backend not in self._aio_helper_map:
-            raise ValueError('The async backend {} is not currently supported.'.format(async_backend))
+            raise ValueError(
+                'The async backend {} is not currently supported.'
+                .format(async_backend)
+            )
         self.awaitable, self.cb_arg = self._aio_helper_map[async_backend](self)
         aio_p = ffi.new('nng_aio **')
         _aio_map[id(self.cb_arg)] = self.cb_arg
@@ -201,5 +204,3 @@ class AIOHelper:
 
     def __del__(self):
         self._free()
-
-

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -657,7 +657,7 @@ class Dialer:
 
 
 class Listener:
-    """Wrapper class for the nng_dialer struct."""
+    """Wrapper class for the nng_listener struct."""
 
     local_address = SockAddrOption('local-address')
     remote_address = SockAddrOption('remote-address')
@@ -866,7 +866,7 @@ def _nng_pipe_cb(lib_pipe, event, arg):
             for cb in sock._on_pre_pipe_add:
                 try:
                     cb(pipe)
-                except:
+                except Exception:
                     msg = 'Exception raised in pre pipe connect callback'
                     logger.exception(msg)
             if pipe.closed:
@@ -879,7 +879,7 @@ def _nng_pipe_cb(lib_pipe, event, arg):
             for cb in sock._on_post_pipe_add:
                 try:
                     cb(pipe)
-                except:
+                except Exception:
                     msg = 'Exception raised in post pipe connect callback'
                     logger.exception(msg)
         elif event == lib.NNG_PIPE_EV_REM_POST:
@@ -894,7 +894,7 @@ def _nng_pipe_cb(lib_pipe, event, arg):
                 for cb in sock._on_post_pipe_remove:
                     try:
                         cb(pipe)
-                    except:
+                    except Exception:
                         msg = 'Exception raised in post pipe remove callback'
                         logger.exception(msg)
             finally:
@@ -1087,4 +1087,3 @@ class Message:
         if self._mem_freed:
             msg = 'Attempted to send the same message more than once.'
             raise pynng.MessageStateError(msg)
-

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -1,9 +1,11 @@
 import asyncio
 import threading
 import time
+import itertools
 
 import pytest
 import trio
+from trio.testing import trio_test
 
 import pynng
 
@@ -89,3 +91,48 @@ def test_asend_trio():
             pynng.Pair0(dial=addr, send_timeout=2000) as dialer:
         msg = trio.run(asend_and_arecv, dialer, listener, b'hello there')
         assert msg == b'hello there'
+
+
+@trio_test
+async def test_pub_sub_trio():
+
+    def is_even(i):
+        return i % 2 == 0
+
+    async def pub():
+        with pynng.Pub0(listen=addr) as pubber:
+            for i in range(1000):
+                prefix = 'even' if is_even(i) else 'odd'
+                msg = '{}:{}'.format(prefix, i)
+                await pubber.asend(msg.encode('ascii'))
+
+            # signal completion
+            await pubber.asend(b'odd:None')
+            await pubber.asend(b'even:None')
+
+    async def subs(which):
+        if which == 'even':
+            pred = is_even
+        else:
+            pred = lambda i: not is_even(i)
+
+        with pynng.Sub0(dial=addr) as subber:
+            subber.subscribe(which + ':')
+
+            while True:
+                val = await subber.arecv()
+
+                lot, _, i = val.partition(b':')
+
+                if i == b'None':
+                    break
+
+                assert pred(int(i))
+
+    async with trio.open_nursery() as n:
+        # whip up the subs
+        for _, lot in itertools.product(range(1), ('even', 'odd')):
+            n.start_soon(subs, lot)
+
+        # head over to the
+        await pub()

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -95,7 +95,13 @@ def test_asend_trio():
 
 @trio_test
 async def test_pub_sub_trio():
+    """Demonstrate pub-sub protocol use with ``trio``.
 
+    Start a publisher which publishes 1000 integers and marks each value
+    as *even* or *odd* (its parity). Spawn 4 subscribers (2 for consuming
+    the evens and 2 for consuming the odds) in separate tasks and have each
+    one retreive values and verify the parity.
+    """
     def is_even(i):
         return i % 2 == 0
 
@@ -134,5 +140,5 @@ async def test_pub_sub_trio():
         for _, lot in itertools.product(range(1), ('even', 'odd')):
             n.start_soon(subs, lot)
 
-        # head over to the
+        # head over to the pub
         await pub()


### PR DESCRIPTION
Adding a `trio` based pub-sub test to decipher the API and figure out the data type details.

One thing I noticed is that you have to pass `bytes` to the [message allocator in `asend()`](https://github.com/codypiersall/pynng/blob/master/pynng/_aio.py#L175).
Is this maybe something that should be encoded by default?
The error I originally got was a bit cryptic.

Also what do you think about adding this example to the docs? 