### PR TITLE
add curio support

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       CIBW_SKIP: "cp27-* cp35-* pp27-* pp36-win32"
       CIBW_BEFORE_BUILD_LINUX: pip install cmake
-      CIBW_TEST_REQUIRES: pytest pytest-trio pytest-asyncio trio
+      CIBW_TEST_REQUIRES: pytest pytest-trio pytest-asyncio trio curio git+https://github.com/johnnoone/pytest-curio.git#master
       CIBW_TEST_COMMAND: pytest -v {project}/test
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -17,5 +17,5 @@ jobs:
           architecture: x64
       - run: sudo apt install -y ninja-build
       - run: python setup.py develop
-      - run: pip install trio pytest pytest-trio pytest-asyncio
+      - run: pip install trio curio pytest pytest-trio pytest-asyncio git+https://github.com/johnnoone/pytest-curio.git#master
       - run: pytest -v test

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Building from the GitHub repo works as well, natch:
     cd pynng
     pip3 install -e .
 
-(If you want to run tests, you also need to `pip3 install pytest` and `pip3
-install trio`, then just run `pytest`.)
+(If you want to run tests, you also need to `pip3 install trio curio pytest pytest-asyncio pytest-trio pytest-curio`,
+then just run `pytest`.)
 
 pynng might work on the BSDs as well.  Who knows!
 
@@ -76,7 +76,7 @@ with Pair0(listen='tcp://127.0.0.1:54321') as s1, \
 
 Asynchronous sending also works with
 
-[trio](https://trio.readthedocs.io/en/latest/) and
+[curio](https://github.com/dabeaz/curio), [trio](https://trio.readthedocs.io/en/latest/) and
 [asyncio](https://docs.python.org/3/library/asyncio.html).  Here is an example
 using trio:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,9 @@ This directory contains examples on using pynng for different tasks.
   pair0.  Adapted from [nng pair
   example](https://nanomsg.org/gettingstarted/nng/pair.html).
 * [`pair1_async.py`](./pair1_async.py): Demonstrates a polyamorous pair1
-  connection.
+  connection using trio.
+* [`pair1_async_curio.py`](./pair1_async.py): Demonstrates a polyamorous pair1
+  connection using curio.
 
 Adding an Example
 -----------------

--- a/examples/pair1_async_curio.py
+++ b/examples/pair1_async_curio.py
@@ -1,0 +1,100 @@
+"""
+Demonstrate how to use a pair1 socket.
+
+Pair1 sockets are similar to pair0 sockets.  The difference is that while pair0
+supports only a single connection, pair1 sockets support _n_ one-to-one
+connections.
+
+This program demonstrates how to use pair1 sockets.  The key differentiator is
+that with pair1 sockets, you must always specify the *pipe* that you want to
+use for the message.
+
+To use this program, you must start several nodes.  One node will be the
+listener, and all other nodes will be dialers.  In one terminal, you must start
+a listener:
+
+    python pair1_async.py listen tcp://127.0.0.1:12345
+
+And in as many separate terminals as you would like, start some dialers:
+
+    # run in as many separate windows as you wish
+    python pair1_async.py dial tcp://127.0.0.1:12345
+
+Whenever you type into the dialer processes, whatever you type is received on
+the listening process.  Whatever you type into the listening process is sent to
+*all* the dialing processes.
+
+"""
+
+import argparse
+import sys
+import pynng
+import curio
+
+
+async def send_eternally(sock):
+    """
+    Eternally listen for user input in the terminal and send it on all
+    available pipes.
+    """
+    stdin = curio.io.FileStream(sys.stdin.buffer)
+    while stdin:
+        line = await stdin.read(1024)
+        if not line:
+            break
+        text = line.decode('utf-8')
+        for pipe in sock.pipes:
+            await pipe.asend(text.encode())        
+
+
+async def recv_eternally(sock):
+    while True:
+        msg = await sock.arecv_msg()
+        source_addr = str(msg.pipe.remote_address)
+        content = msg.bytes.decode()
+        print('{} says: {}'.format(source_addr, content))
+
+
+async def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        'mode',
+        help='Whether the socket should "listen" or "dial"',
+        choices=['listen', 'dial'],
+    )
+    p.add_argument(
+        'addr',
+        help='Address to listen or dial; e.g. tcp://127.0.0.1:13134',
+    )
+    args = p.parse_args()
+
+    with pynng.Pair1(polyamorous=True) as sock:
+        async with curio.TaskGroup(wait=any) as g:
+            if args.mode == 'listen':
+                # the listening socket can get dialled by any number of dialers.
+                # add a couple callbacks to see when the socket is receiving
+                # connections.
+                def pre_connect_cb(pipe):
+                    addr = str(pipe.remote_address)
+                    print('~~~~got connection from {}'.format(addr))
+
+                def post_remove_cb(pipe):
+                    addr = str(pipe.remote_address)
+                    print('~~~~goodbye for now from {}'.format(addr))
+                sock.add_pre_pipe_connect_cb(pre_connect_cb)
+                sock.add_post_pipe_remove_cb(post_remove_cb)
+                sock.listen(args.addr)
+            else:
+                sock.dial(args.addr)
+
+            await g.spawn(recv_eternally, sock)
+            await g.spawn(send_eternally, sock)
+
+
+
+if __name__ == '__main__':
+    try:
+        curio.run(main)
+    except KeyboardInterrupt:
+        # that's the way the program *should* end
+        pass

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,9 @@ tests_require = [
     'pytest',
     'pytest-asyncio',
     'pytest-trio',
+    'pytest-curio',
     'trio',
+    'curio'
 ]
 
 setuptools.setup(
@@ -173,6 +175,7 @@ setuptools.setup(
         'Development Status :: 3 - Alpha',
         'Framework :: AsyncIO',
         'Framework :: Trio',
+        'Framework :: Curio',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Hello,

Thanks a lot for your work, I take hours of good learning, (starting from 0mq, and it's not all done for now, so really thanks you).

As I using more often curio async framework, I've added aio helper implementation for it.
I hope that I did not go away of something more smart (...)

The example 'pair1_async_curio.py' worked fine for me, and few test unit are ok with the last github version of pytest-curio.

About pytest-curio, i've made a pull request on (https://github.com/johnnoone/pytest-curio/pull/5), which has just been accepted, so as soon it will be available on pypi, a simple pip install pytest-curio will be enought.

If all is ok, it could close this issue: https://github.com/codypiersall/pynng/issues/23

Regards,
Jerome
