### PR TITLE
Introduce block-argument to send

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Building from the GitHub repo works as well, natch:
     pip3 install -e .
 
 (If you want to run tests, you also need to `pip3 install trio curio pytest pytest-asyncio pytest-trio pytest-curio`,
-then just run `pytest`.)
+then just run `pytest test`.)
 
 pynng might work on the BSDs as well.  Who knows!
 

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -456,10 +456,23 @@ class Socket:
         lib.nng_free(data[0], size_t[0])
         return recvd
 
-    def send(self, data):
-        """Sends ``data`` (either ``bytes`` or ``bytearray``) on socket."""
+    def send(self, data, block=True):
+        """Sends ``data`` on socket.
+
+        Args:
+
+          data: either ``bytes`` or ``bytearray``
+
+          block: If block is True (the default), the function will
+          not return until the operation is completed or times out.
+          If block is False, the function will raise ``pynng.TryAgain``
+          immediately if no data was sent.
+        """
         _ensure_can_send(data)
-        err = lib.nng_send(self.socket, data, len(data), 0)
+        flags = 0
+        if not block:
+            flags |= lib.NNG_FLAG_NONBLOCK
+        err = lib.nng_send(self.socket, data, len(data), flags)
         check_err(err)
 
     async def arecv(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -57,6 +57,12 @@ def test_nonblocking_recv_works():
             s.recv(block=False)
 
 
+def test_nonblocking_send_works():
+    with pynng.Pair0(listen=addr) as s:
+        with pytest.raises(pynng.TryAgain):
+            s.send(b'sad message, never will be seen', block=False)
+
+
 @pytest.mark.trio
 async def test_context():
     with pynng.Req0(listen=addr, recv_timeout=1000) as req_sock, \


### PR DESCRIPTION
By default, sending blocks. When block=False, raise pynng.TryAgain
if no data could be delivered.