### PR TITLE
Do not link libatomic on M1 Macs

### DIFF
--- a/build_pynng.py
+++ b/build_pynng.py
@@ -28,7 +28,7 @@ else:
     machine = os.uname().machine
     # this is a pretty heuristic... but let's go with it anyway.
     # it would be better to get linker information from cmake somehow.
-    if not ('x86' in machine or 'i386' in machine or 'i686' in machine):
+    if not ('x86' in machine or 'i386' in machine or 'i686' in machine or 'arm64' in machine):
         libraries.append('atomic')
 
 


### PR DESCRIPTION
This adds onto the heuristic, hopefully without breaking other ARM users, and fixes build of pynng on M1 Macbooks. Tested successfully via pip install.

```
      ld: library not found for -latomic
      clang: error: linker command failed with exit code 1 (use -v to see invocation)
      error: command '/usr/bin/clang' failed with exit code 1
```