### PR TITLE
Do not log the exception before attempting an non-blocking dial

### DIFF
--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -373,8 +373,6 @@ class Socket:
             try:
                 return self.dial(address, block=True)
             except pynng.ConnectionRefused:
-                msg = 'Synchronous dial failed; attempting asynchronous now'
-                logger.exception(msg)
                 return self.dial(address, block=False)
         else:
             return self._dial(address, flags=lib.NNG_FLAG_NONBLOCK)


### PR DESCRIPTION
When the `block` argument is not specified or is set to `None` during a call to `dial()`, the library tries to do a blocking connection first.
If a `pynng.ConnectionRefused` occurs, the exception is logged using the global logger and then a non-blocking connection is attempted.

In my opinion the exception should not be logged (especially using the global logger).
I've spent 2 hours figuring out that the exception displayed in my terminal does not occur in my code and is "normal" because I did not specified the `block` argument 😀

Here a small code example:

```python
from pynng import Req0, NNGException

try:
    with Req0(dial="tcp://127.0.0.1:9093") as sock:
        sock.send_timeout = 3000
        sock.recv_timeout = 3000
        sock.send(b"my_data")
except NNGException as err:
    print(f"Exception occured in my code: {err}")
```

The output **without** this patch:
```
Synchronous dial failed; attempting asynchronous now
Traceback (most recent call last):
  File "/home/olivier/dev/tests/pynng-fix/pynng-master/pynng/nng.py", line 374, in dial
    return self.dial(address, block=True)
  File "/home/olivier/dev/tests/pynng-fix/pynng-master/pynng/nng.py", line 371, in dial
    return self._dial(address, flags=0)
  File "/home/olivier/dev/tests/pynng-fix/pynng-master/pynng/nng.py", line 390, in _dial
    check_err(ret)
  File "/home/olivier/dev/tests/pynng-fix/pynng-master/pynng/exceptions.py", line 201, in check_err
    raise exc(string, err)
pynng.exceptions.ConnectionRefused: Connection refused
Exception occured in my code: Timed out
```

The output **with** this patch:

```
Exception occured in my code: Timed out