### PR TITLE
Fix: Compilation for both macOS architectures.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ test-skip = "cp312*"
 # architectures, and that's no good.
 before-build = "bash .github/rmstuff.sh"
 
+[tool.cibuildwheel.macos]
+# Specify universal2 building for macOS
+archs = ["universal2"]
+environment = { CMAKE_OSX_ARCHITECTURES="x86_64;arm64" }
+
 [tool.black]
 # Just a placeholder because I have a plugin that won't run without a section in
 # pyproject.toml


### PR DESCRIPTION
This fixes an issue with the compilation of Apple Silicon architecture, which was re-introduced with ded2448. With this fix, `pynng` is again compiled as a `universal2` wheel, which works on both `x86_64` and `arm64` architecture.

@codypiersall: Would be great, if you could merge this and upload the new universal2 wheels to PiPy. Thanks! :)