### PR TITLE
fix: force nng checkout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class BuilderBase(Command):
         """Clone nng and build it with cmake, with TLS enabled."""
         if not os.path.exists(self.git_dir):
             check_call("git clone {}".format(self.repo), shell=True)
-            check_call("git checkout {}".format(self.rev), shell=True, cwd=self.git_dir)
+            check_call("git checkout -f {}".format(self.rev), shell=True, cwd=self.git_dir)
         if not os.path.exists(self.build_dir):
             os.mkdir(self.build_dir)
 


### PR DESCRIPTION
to prevent build failures like

```
error: The following untracked working tree files would be overwritten by checkout:
        cmake/FindmbedTLS.cmake
```

seems to be caused by case sensitivity differences beween file systems (FindmbedTLS.cmake vs FindMbedTLS.cmake)