### PR TITLE
Remove "build-deps" user option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,9 +149,6 @@ class BuildBuild(build_ext):
     # dbuild.user_options += [
     #    ('build-deps', None, 'build nng and mbedtls before building the module')
     # ]
-    build_ext.user_options += [
-        ("build-deps", None, "build nng and mbedtls before building the module")
-    ]
 
     def initialize_options(self):
         """
@@ -160,15 +157,13 @@ class BuildBuild(build_ext):
         """
         # dbuild.initialize_options(self)
         build_ext.initialize_options(self)
-        self.build_deps = "yes"
 
     def run(self):
         """
         Running...
         """
-        if self.build_deps:
-            self.run_command("build_mbedtls")
-            self.run_command("build_nng")
+        self.run_command("build_mbedtls")
+        self.run_command("build_nng")
 
         # dbuild.run(self) # proceed with "normal" build steps
         build_ext.run(self)  # proceed with "normal" build steps


### PR DESCRIPTION
Remove the superfluous user option "build-deps". This option which could have been used to disable building the  `nng` and `mbedtls` libraries in setup.cfg.

Currently, this not possible because the if-statement checks with a logical operator instead of checking the string content.

Also, it is not clear to me, if it would even make sense to disable building the libraries, the build would fail because it does not offer an alternative like dynamically linking against a pre-compiled libnng.

In addition, using the `build-deps` config in setup.cfg resulted in a warning:

```
/tmp/build-env-u3os25k0/lib/python3.10/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
!!

        ********************************************************************************
        Usage of dash-separated 'build-deps' will not be supported in future
        versions. Please use the underscore name 'build_deps' instead.

        By 2024-Sep-26, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!

```