### PR TITLE
Update cibuildwheel Github action to 2.17.0

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.17.0
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Updating the `cibuildwheel` Github action is needed to get successful builds at least for the Windows build.

Release notes for 2.17.0: https://github.com/pypa/cibuildwheel/releases/tag/v2.17.0

It looks like this PR fixed the issue https://github.com/pypa/cibuildwheel/releases/tag/v2.17.0.