### PR TITLE
Bump cibuildwheel to build cpython 3.13 wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.21.3
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
CPython 3.13.0 was released on Oct. 7, 2024.
Bumping cibuildwheel to latest version, it will build wheels for 3.13 too.