### PR TITLE
Pair1 fixes

### DIFF
--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -741,8 +741,8 @@ class Pair1(Socket):
 
     .. Warning::
 
-        Pair1 was an experimental feature in nng, and is currently deprecated.
-        It will likely be removed in the future; see `nng's docs
+        Polyamorous mode was an experimental feature in nng, and is currently
+        deprecated. It will likely be removed in the future; see `nng's docs
         <https://nng.nanomsg.org/man/v1.3.2/nng_pair_open.3.html>`_ for
         details.
 
@@ -769,19 +769,18 @@ class Pair1(Socket):
         # them out of kwargs, then do the dial/listen below.
         # It's not beautiful, but it will work.
         dial_addr = kwargs.pop("dial", None)
-        listen_addr = kwargs.pop("dial", None)
-        super().__init__(**kwargs)
+        listen_addr = kwargs.pop("listen", None)
         if polyamorous:
-            self._opener = lib.nng_pair1_open_poly
+            opener = lib.nng_pair1_open_poly
         else:
-            self._opener = lib.nng_pair1_open
+            opener = lib.nng_pair1_open
+        super().__init__(opener=opener, **kwargs)
         # now we can do the listen/dial
         if dial_addr is not None:
             self.dial(dial_addr, block=kwargs.get("block_on_dial"))
         if listen_addr is not None:
             self.listen(listen_addr)
 
-    _opener = lib.nng_pair1_open_poly
     polyamorous = BooleanOption("pair1:polyamorous")
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -139,9 +139,6 @@ def test_pair1_polyamorousness():
 
             p2.send(b"hello there s2")
             assert s2.recv() == b"hello there s2"
-            # TODO: Should *not* need to do this sleep, but stuff hangs without
-            # it.
-            time.sleep(0.05)
 
 
 # ToDo: Check in detail what is going wrong on pp3x-* wheels! Skipping for now.


### PR DESCRIPTION
This PR fixes a couple of issues with the Pair1 socket:

1. Pair1 would *always* use the `nng_pair1_open_poly` opener, because `self._opener` was set in `Pair1.__init__()` after the `super().__init__()` call.
2. `listen_addr` would always be None, because it was mistakenly popping `dial` instead of `listen`, and `dial` had already been popped. So the default listen it was trying to prevent in `super().__init__()` would actually occur.
3. The documentation for Pair1 mistakenly says that the Pair1 protocol is experimental and deprecated. What is deprecated is the `polyamorous` mode of Pair1.
