### PR TITLE
Fix documentation formatting

### DIFF
--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -481,9 +481,9 @@ class Socket:
           data: either ``bytes`` or ``bytearray``
 
           block: If block is True (the default), the function will
-          not return until the operation is completed or times out.
-          If block is False, the function will raise ``pynng.TryAgain``
-          immediately if no data was sent.
+            not return until the operation is completed or times out.
+            If block is False, the function will raise ``pynng.TryAgain``
+            immediately if no data was sent.
         """
         _ensure_can_send(data)
         flags = 0


### PR DESCRIPTION
Fix small issue in formatting of parameter. Causes parameter documentation to not be possible to read.

https://pynng.readthedocs.io/en/latest/core.html#pynng.Socket.send

<img width="2123" height="711" alt="image" src="https://github.com/user-attachments/assets/7e8b6be6-11d3-4ed8-981d-91b718d838da" />