### PR TITLE
fix: CI. Cibuildwheel update to 3.1.4

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -22,6 +22,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.1.4

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -11,7 +11,7 @@ jobs:
         os: [
           ubuntu-24.04,
           ubuntu-24.04-arm,
-          windows-11-arm,
+          # windows-11-arm,
           windows-2025,
           macos-15,
         ]

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,7 +15,8 @@ jobs:
           windows-2025,
           macos-15,
         ]
-
+      # don't let one failing job cancel all the others.
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -8,21 +8,36 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [
+          ubuntu-24.04,
+          ubuntu-24.04-arm,
+          windows-11-arm,
+          windows-2025,
+          macos-15,
+        ]
+
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.1.4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
+
   # create the source distribution
   make_sdist:
     name: Make SDist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/build_pynng.py
+++ b/build_pynng.py
@@ -37,15 +37,12 @@ else:
     ]
     libraries = ["pthread"]
     machine = os.uname().machine
-    # this is a pretty heuristic... but let's go with it anyway.
+    # this is a pretty gross heuristic... but let's go with it anyway.
     # it would be better to get linker information from cmake somehow.
     # Building process will be broken if add -latomic in Mac with clang. https://github.com/nodejs/node/pull/30099
-    clang = False
-    try:
-        if os.environ["CC"] == "clang":
-            clang = True
-    except KeyError:
-        clang = False
+    clang = (os.environ.get("CC") == "clang") or (
+        sysconfig.get_config_var("CC") == "clang"
+    )
     print("~~~~~~~~~~~~~~~~~")
     print(f"{machine=}")
     print(f"{machine=}")
@@ -61,14 +58,11 @@ else:
     print(f"{os.uname().sysname=}")
     print(f"{os.uname().sysname=}")
     print(f"{os.uname().sysname=}")
-    if sysconfig.get_config_var("CC") == "clang":
-        clang = True
-    if not (
-        "x86" in machine
-        or "i386" in machine
-        or "i686" in machine
-        or (clang and "Darwin" in os.uname().sysname)
-    ):
+
+    if os.uname().sysname == "Darwin":
+        # don't link libatomic on Mac
+        pass
+    elif machine == "aarch64":
         libraries.append("atomic")
 
 

--- a/build_pynng.py
+++ b/build_pynng.py
@@ -43,22 +43,6 @@ else:
     clang = (os.environ.get("CC") == "clang") or (
         sysconfig.get_config_var("CC") == "clang"
     )
-    print("~~~~~~~~~~~~~~~~~")
-    print(f"{machine=}")
-    print(f"{machine=}")
-    print(f"{machine=}")
-    print(f"{machine=}")
-    print(f"{clang=}")
-    print(f"{clang=}")
-    print(f"{clang=}")
-    print(f"{clang=}")
-    print(f"{clang=}")
-    print(f"{os.uname().sysname=}")
-    print(f"{os.uname().sysname=}")
-    print(f"{os.uname().sysname=}")
-    print(f"{os.uname().sysname=}")
-    print(f"{os.uname().sysname=}")
-
     if os.uname().sysname == "Darwin":
         # don't link libatomic on Mac
         pass

--- a/build_pynng.py
+++ b/build_pynng.py
@@ -46,6 +46,21 @@ else:
             clang = True
     except KeyError:
         clang = False
+    print("~~~~~~~~~~~~~~~~~")
+    print(f"{machine=}")
+    print(f"{machine=}")
+    print(f"{machine=}")
+    print(f"{machine=}")
+    print(f"{clang=}")
+    print(f"{clang=}")
+    print(f"{clang=}")
+    print(f"{clang=}")
+    print(f"{clang=}")
+    print(f"{os.uname().sysname=}")
+    print(f"{os.uname().sysname=}")
+    print(f"{os.uname().sysname=}")
+    print(f"{os.uname().sysname=}")
+    print(f"{os.uname().sysname=}")
     if sysconfig.get_config_var("CC") == "clang":
         clang = True
     if not (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test-command = "pytest {project}/test"
 # wheels aren't built correctly for Python 3.6; seems like setuptools doesn't like
 # pyproject.toml for that old Python.
 # pypy3.9 fails on Windows for some reason
-skip = "cp36-* pp39-win_amd64 pp310-win_amd64 cp314-*"
+skip = "cp36-* pp39-win_amd64 pp310-win_amd64 cp314*"
 
 build-verbosity = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ include = ["pynng"]
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools",
+    "setuptools==75.3.2",
     "setuptools-scm",
     "cffi",
     "cmake",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test-command = "pytest {project}/test"
 # wheels aren't built correctly for Python 3.6; seems like setuptools doesn't like
 # pyproject.toml for that old Python.
 # pypy3.9 fails on Windows for some reason
-skip = "cp36-* pp39-win_amd64 pp310-win_amd64"
+skip = "cp36-* pp39-win_amd64 pp310-win_amd64 cp314-*"
 
 build-verbosity = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "sniffio",
 ]
 description = "Networking made simply using nng"
-license = {file = "LICENSE.txt"}
+license-files = ["LICENSE.txt"]
 dynamic = ["version"]
 keywords = [
     "networking",
@@ -82,10 +82,8 @@ test-requires = [
 
 test-command = "pytest {project}/test"
 
-# wheels aren't built correctly for Python 3.6; seems like setuptools doesn't like
-# pyproject.toml for that old Python.
-# pypy3.9 fails on Windows for some reason
-skip = "cp36-* pp39-win_amd64 pp310-win_amd64 cp314*"
+# 3.14 does not have cffi support yet (Sep. 2025)
+skip = "cp314*"
 
 build-verbosity = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,7 @@ test-requires = [
 test-command = "pytest {project}/test"
 
 # 3.14 does not have cffi support yet (Sep. 2025)
-# skip = "cp314*"
-
-only = "*mac*"
+skip = "cp314*"
 
 build-verbosity = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ dependencies = [
     "sniffio",
 ]
 description = "Networking made simply using nng"
-license-files = ["LICENSE.txt"]
+# Note: when we drop Python 3.8 we can use the new license version and CI won't yell at
+# setuptools 3.8 requires this version.
+# uncomment when dropping python3.8
+# license = "MIT"
+license = {file = "LICENSE.txt"}
 dynamic = ["version"]
 keywords = [
     "networking",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,9 @@ test-requires = [
 test-command = "pytest {project}/test"
 
 # 3.14 does not have cffi support yet (Sep. 2025)
-skip = "cp314*"
+# skip = "cp314*"
+
+only = "*mac*"
 
 build-verbosity = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ environment = { CMAKE_OSX_ARCHITECTURES="x86_64;arm64" }
 [tool.black]
 # Just a placeholder because I have a plugin that won't run without a section in
 # pyproject.toml
+target-version = ["py38"]
 
 # pytest configuration
 [tool.pytest.ini_options]

--- a/test/test_abstract.py
+++ b/test/test_abstract.py
@@ -45,10 +45,9 @@ def test_abstract_socket_connection():
     # Test with a simple abstract socket name
     abstract_addr = "abstract://test_socket"
 
-    with (
-        pynng.Pair0(recv_timeout=1000) as sock1,
-        pynng.Pair0(recv_timeout=1000) as sock2,
-    ):
+    with pynng.Pair0(recv_timeout=1000) as sock1, pynng.Pair0(
+        recv_timeout=1000
+    ) as sock2:
         # Test listening on abstract socket
         listener = sock1.listen(abstract_addr)
         assert len(sock1.listeners) == 1
@@ -142,10 +141,9 @@ def test_abstract_socket_with_different_protocols():
         max_retries = 5
         for retry in range(max_retries):
             try:
-                with (
-                    server_proto(recv_timeout=100) as server,
-                    client_proto(recv_timeout=100) as client,
-                ):
+                with server_proto(recv_timeout=100) as server, client_proto(
+                    recv_timeout=100
+                ) as client:
                     if server_proto == pynng.Pub0 and client_proto == pynng.Sub0:
                         # Special handling for pub/sub
                         server.listen(abstract_addr)


### PR DESCRIPTION
Build wheels in CI successfully again. Cannot build for Python 3.14 yet.