### PR TITLE
Async ergonomics: context managers, iterators, and aclose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `async with` context manager support for sockets (`async with pynng.Pair0() as sock:`)
+- `async for` iteration over received messages (`async for msg in sock:`)
+- `aclose()` method for explicit async socket cleanup
+- `async with` context manager support for `Dialer` and `Listener`
+- `aclose()` method for `Dialer` and `Listener`
+- `recv_timeout` and `send_timeout` option descriptors on `Context` for per-context timeout control
+
 ### Changed
 - Switch cibuildwheel to uv build frontend, eliminating virtualenv.pyz downloads
 - Migrate build system from setuptools/CMake to scikit-build-core with headerkit for C header generation

--- a/pynng/_aio.py
+++ b/pynng/_aio.py
@@ -8,7 +8,6 @@ import sniffio
 from ._nng import ffi, lib
 import pynng
 from .exceptions import check_err
-import concurrent
 
 # global variable for mapping asynchronous operations with the Python data
 # assocated with them.  Key is id(obj), value is obj
@@ -26,32 +25,10 @@ def _async_complete(void_p):
     assert isinstance(void_p, ffi.CData)
     id = int(ffi.cast("size_t", void_p))
 
-    rescheduler = _aio_map.pop(id)
+    rescheduler = _aio_map.pop(id, None)
+    if rescheduler is None:
+        return
     rescheduler()
-
-
-def curio_helper(aio):
-    import curio
-
-    fut = concurrent.futures.Future()
-
-    async def wait_for_aio():
-        try:
-            await curio.traps._future_wait(fut)
-        except curio.CancelledError:
-            if fut.cancelled():
-                lib.nng_aio_cancel(aio.aio)
-
-        err = lib.nng_aio_result(aio.aio)
-        if err == lib.NNG_ECANCELED:
-            raise curio.CancelledError()
-        check_err(err)
-
-    def callback():
-        if not fut.cancelled():
-            fut.set_result(True)
-
-    return wait_for_aio(), callback
 
 
 def asyncio_helper(aio):
@@ -60,7 +37,7 @@ def asyncio_helper(aio):
     responsible for rescheduling the event loop
 
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     fut = loop.create_future()
 
     async def wait_for_aio():
@@ -148,7 +125,6 @@ class AIOHelper:
     _aio_helper_map = {
         "asyncio": asyncio_helper,
         "trio": trio_helper,
-        "curio": curio_helper,
     }
 
     def __init__(self, obj, async_backend):

--- a/pynng/nng.py
+++ b/pynng/nng.py
@@ -509,6 +509,28 @@ class Socket:
     def __exit__(self, *tb_info):
         self.close()
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *tb_info):
+        """Close the socket. Delegates to synchronous close() since the
+        underlying NNG close operation is non-blocking."""
+        self.close()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return await self.arecv()
+        except pynng.Closed:
+            raise StopAsyncIteration
+
+    async def aclose(self):
+        """Asynchronous close. Delegates to the synchronous :meth:`close`
+        since the underlying NNG close operation is non-blocking."""
+        self.close()
+
     @property
     def dialers(self):
         """A list of the active dialers"""
@@ -1100,6 +1122,19 @@ class Dialer:
     def id(self):
         return lib.nng_dialer_id(self.dialer)
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        if self.id in self.socket._dialers:
+            self.close()
+
+    async def aclose(self):
+        """Asynchronous close. Delegates to the synchronous :meth:`close`
+        since the underlying NNG close operation is non-blocking."""
+        if self.id in self.socket._dialers:
+            self.close()
+
 
 class Listener:
     """The Python version of `nng_listener
@@ -1157,6 +1192,19 @@ class Listener:
     def id(self):
         return lib.nng_listener_id(self.listener)
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        if self.id in self.socket._listeners:
+            self.close()
+
+    async def aclose(self):
+        """Asynchronous close. Delegates to the synchronous :meth:`close`
+        since the underlying NNG close operation is non-blocking."""
+        if self.id in self.socket._listeners:
+            self.close()
+
 
 class Context:
     """
@@ -1207,6 +1255,9 @@ class Context:
     :class:`Socket`, and call the :meth:`~Socket.new_context` method.
 
     """
+
+    recv_timeout = MsOption("recv-timeout")
+    send_timeout = MsOption("send-timeout")
 
     def __init__(self, socket):
         # need to set attributes first, so that if anything goes wrong,
@@ -1291,6 +1342,28 @@ class Context:
         return self
 
     def __exit__(self, *exc_info):
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        """Close the context. Delegates to synchronous close() since the
+        underlying NNG close operation is non-blocking."""
+        self.close()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return await self.arecv()
+        except pynng.Closed:
+            raise StopAsyncIteration
+
+    async def aclose(self):
+        """Asynchronous close. Delegates to the synchronous :meth:`close`
+        since the underlying NNG close operation is non-blocking."""
         self.close()
 
     @property

--- a/test/test_async_ergonomics.py
+++ b/test/test_async_ergonomics.py
@@ -1,0 +1,94 @@
+"""Tests for async ergonomics: async context managers for Dialer and Listener."""
+
+import pytest
+import trio
+
+import pynng
+
+addr = "inproc://test-async-ergonomics"
+
+
+@pytest.mark.trio
+async def test_dialer_async_context_manager_trio():
+    """Dialer can be used as an async context manager with trio."""
+    with pynng.Pair0(listen=addr + "-dialer-trio") as listener_sock:
+        with pynng.Pair0() as dialer_sock:
+            dialer = dialer_sock.dial(addr + "-dialer-trio", block=True)
+            async with dialer:
+                await dialer_sock.asend(b"hello from dialer")
+                assert (await listener_sock.arecv()) == b"hello from dialer"
+            # after exiting async with, dialer is closed
+
+
+@pytest.mark.trio
+async def test_listener_async_context_manager_trio():
+    """Listener can be used as an async context manager with trio."""
+    with pynng.Pair0() as sock:
+        async with sock.listen(addr + "-listener-trio") as listener:
+            assert listener is not None
+        # after exiting async with, listener is closed
+
+
+@pytest.mark.asyncio
+async def test_dialer_async_context_manager_asyncio():
+    """Dialer can be used as an async context manager with asyncio."""
+    with pynng.Pair0(listen=addr + "-dialer-asyncio") as listener_sock:
+        with pynng.Pair0() as dialer_sock:
+            dialer = dialer_sock.dial(addr + "-dialer-asyncio", block=True)
+            async with dialer:
+                await dialer_sock.asend(b"hello from dialer")
+                assert (await listener_sock.arecv()) == b"hello from dialer"
+
+
+@pytest.mark.asyncio
+async def test_listener_async_context_manager_asyncio():
+    """Listener can be used as an async context manager with asyncio."""
+    with pynng.Pair0() as sock:
+        async with sock.listen(addr + "-listener-asyncio") as listener:
+            assert listener is not None
+
+
+@pytest.mark.trio
+async def test_dialer_aclose_trio():
+    """Dialer.aclose() works correctly and verifies closed state."""
+    with pynng.Pair0(listen=addr + "-aclose-trio") as listener_sock:
+        with pynng.Pair0() as dialer_sock:
+            dialer = dialer_sock.dial(addr + "-aclose-trio", block=True)
+            await dialer.aclose()
+            assert dialer.id not in dialer_sock._dialers
+            # calling aclose again should be idempotent (no error)
+            await dialer.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dialer_aclose_asyncio():
+    """Dialer.aclose() works correctly with asyncio."""
+    with pynng.Pair0(listen=addr + "-aclose-asyncio-d") as listener_sock:
+        with pynng.Pair0() as dialer_sock:
+            dialer = dialer_sock.dial(addr + "-aclose-asyncio-d", block=True)
+            await dialer.aclose()
+            assert dialer.id not in dialer_sock._dialers
+            # calling aclose again should be idempotent (no error)
+            await dialer.aclose()
+
+
+@pytest.mark.asyncio
+async def test_listener_aclose_asyncio():
+    """Listener.aclose() works correctly and verifies closed state."""
+    with pynng.Pair0() as sock:
+        listener = sock.listen(addr + "-aclose-asyncio")
+        await listener.aclose()
+        assert listener.id not in sock._listeners
+        # calling aclose again should be idempotent (no error)
+        await listener.aclose()
+
+
+@pytest.mark.trio
+async def test_listener_aclose_trio():
+    """Listener.aclose() works correctly with trio."""
+    with pynng.Pair0() as sock:
+        listener = sock.listen(addr + "-aclose-trio-l")
+        await listener.aclose()
+        assert listener.id not in sock._listeners
+        # calling aclose again should be idempotent (no error)
+        await listener.aclose()

--- a/test/test_context_options.py
+++ b/test/test_context_options.py
@@ -1,0 +1,66 @@
+"""Tests for per-context option descriptors (recv_timeout, send_timeout)."""
+
+import pynng
+import pytest
+
+addr = "inproc://test-context-options"
+
+
+def test_context_recv_timeout_get_set():
+    """recv_timeout can be get/set on a context independently of the socket."""
+    with pynng.Rep0(listen=addr) as s:
+        ctx = s.new_context()
+        try:
+            # default is -1 (infinite)
+            assert ctx.recv_timeout == -1
+            ctx.recv_timeout = 100
+            assert ctx.recv_timeout == 100
+            # socket timeout should still be default
+            assert s.recv_timeout == -1
+        finally:
+            ctx.close()
+
+
+def test_context_send_timeout_get_set():
+    """send_timeout can be get/set on a context independently of the socket."""
+    with pynng.Rep0(listen=addr + "-send") as s:
+        ctx = s.new_context()
+        try:
+            assert ctx.send_timeout == -1
+            ctx.send_timeout = 200
+            assert ctx.send_timeout == 200
+            assert s.send_timeout == -1
+        finally:
+            ctx.close()
+
+
+def test_two_contexts_independent_timeouts():
+    """Two contexts on the same socket can have different timeouts."""
+    with pynng.Rep0(listen=addr + "-independent") as s:
+        ctx1 = s.new_context()
+        ctx2 = s.new_context()
+        try:
+            ctx1.recv_timeout = 50
+            ctx2.recv_timeout = 500
+            ctx1.send_timeout = 100
+            ctx2.send_timeout = 1000
+
+            assert ctx1.recv_timeout == 50
+            assert ctx2.recv_timeout == 500
+            assert ctx1.send_timeout == 100
+            assert ctx2.send_timeout == 1000
+        finally:
+            ctx1.close()
+            ctx2.close()
+
+
+def test_context_timeout_triggers():
+    """Setting a short recv_timeout on a context causes Timeout exception."""
+    with pynng.Rep0(listen=addr + "-timeout") as s:
+        ctx = s.new_context()
+        try:
+            ctx.recv_timeout = 1  # 1 ms
+            with pytest.raises(pynng.Timeout):
+                ctx.recv()
+        finally:
+            ctx.close()


### PR DESCRIPTION
Add standard Python async protocol support to Socket, Context, Dialer, and Listener.

## Before

```python
sock = pynng.Pair0(listen=address)
try:
    while True:
        msg = await sock.arecv()
        process(msg)
finally:
    sock.close()
```

## After

```python
async with pynng.Pair0(listen=address) as sock:
    async for msg in sock:
        process(msg)
```

## Changes

- `async with` support for Socket, Context, Dialer, and Listener
- `async for` iteration over received messages
- `aclose()` for explicit async cleanup with idempotent close behavior
- Per-context `recv_timeout`/`send_timeout` descriptors
- Replace deprecated `get_event_loop()` with `get_running_loop()`
- Remove unmaintained curio backend

## Related Issues

Related to codypiersall/pynng#124 -- replaced deprecated `get_event_loop()` with `get_running_loop()`, which may improve async performance